### PR TITLE
Improve separation of concerns in Chat

### DIFF
--- a/src/app/components/chat/Chat.tsx
+++ b/src/app/components/chat/Chat.tsx
@@ -1,27 +1,19 @@
-import { useEffect, useMemo, useState } from "react";
+import { useState } from "react";
 import * as Ably from "ably";
-import { useChannel, usePresence } from "ably/react";
-import { playerNames } from "../../../gameUtils";
+import { useChannel } from "ably/react";
+import { playerName, playerNames } from "../../../gameUtils";
 import { ChatTypes } from "../../../types";
 import { useGameStateContext } from "../../app";
-
-const TYPING_TIMEOUT = 2000;
-
-const playerName = (playerId: string, players: string[]) => {
-  if (playerId === players[0]) {
-    return playerNames[0];
-  } else if (playerId === players[1]) {
-    return playerNames[1];
-  } else {
-    return;
-  }
-};
+import useTypingStatus from "./useTypingStatus";
+import Status from "./Status";
+import OpponentPresence from "./OpponentPresence";
 
 const Chat = () => {
-  const { playerId, game, setGame, fetchGame, gameResult } =
-    useGameStateContext();
+  const { playerId, game } = useGameStateContext();
 
   if (!game) return;
+
+  const [messages, setMessages] = useState<ChatTypes.Message[]>([]);
 
   const { channel } = useChannel(game.id, (message: Ably.Types.Message) => {
     const { name, clientId, data: text, timestamp, id } = message;
@@ -31,121 +23,26 @@ const Chat = () => {
         { clientId, text, timestamp, id },
       ]);
     }
-
-    if (name === "startedTyping") {
-      setWhoIsCurrentlyTyping((currentlyTyping) => [
-        ...currentlyTyping,
-        clientId,
-      ]);
-    }
-
-    if (name === "stoppedTyping") {
-      setWhoIsCurrentlyTyping((currentlyTyping) =>
-        currentlyTyping.filter((id) => id !== clientId)
-      );
-    }
   });
 
-  const opponentId = game.players.filter((id) => id !== playerId)[0];
+  // Maintain a list of who is currently typing so we can indicate that in the UI
+  const { onType, whoIsCurrentlyTyping } = useTypingStatus(channel, playerId);
 
-  const [messages, setMessages] = useState<ChatTypes.Message[]>([]);
+  // State for the chat text input
   const [inputValue, setInputValue] = useState<string>("");
-  const [timer, setTimer] = useState<NodeJS.Timeout | null>(null);
-  const [startedTyping, setStartedTyping] = useState(false);
-  const [whoIsCurrentlyTyping, setWhoIsCurrentlyTyping] = useState<string[]>(
-    []
-  );
-  const [hasMounted, setHasMounted] = useState(false);
-
-  useEffect(() => {
-    setHasMounted(true);
-  }, []);
-
-  const { presenceData } = usePresence<string>(game.id, "present");
-
-  const [shouldShowOpponentMessage, setShouldShowOpponentMessage] =
-    useState(false);
-
-  const opponentIsHere = useMemo(
-    () => !!presenceData.find((presence) => presence.clientId === opponentId),
-    [presenceData, opponentId]
-  );
-
-  // Create a delay before we show any messages about the opponent leaving.
-  // This gives them a chance to reconnect, AND it prevents any flickering of
-  // this message when the game is initially created.
-  useEffect(() => {
-    let timer: NodeJS.Timeout | undefined = undefined;
-
-    if (!opponentIsHere) {
-      timer = setTimeout(() => {
-        setShouldShowOpponentMessage(true);
-      }, 2000);
-    } else {
-      if (timer !== undefined) {
-        clearTimeout(timer);
-      }
-      setShouldShowOpponentMessage(false);
-    }
-
-    return () => {
-      if (timer !== undefined) {
-        clearTimeout(timer);
-      }
-    };
-  }, [opponentIsHere]);
-
-  const stopTyping = () => {
-    setStartedTyping(false); // Reset the startedTyping state.
-    channel.publish("stoppedTyping", playerId);
-  };
-
-  useEffect(() => {
-    if (!hasMounted) return;
-
-    // If the user hasn't started typing yet, log that they've started typing.
-    if (!startedTyping) {
-      setStartedTyping(true);
-      channel.publish("startedTyping", playerId);
-    }
-
-    // Clear the existing timer if any
-    if (timer) {
-      clearTimeout(timer);
-    }
-
-    if (inputValue === "") {
-      // Send the stopped typing thing right away if there's no value -- this
-      // handles when we've just sent a message.
-      stopTyping();
-    } else {
-      // Set a new timer
-      const newTimer = setTimeout(stopTyping, TYPING_TIMEOUT);
-      setTimer(newTimer);
-    }
-
-    // Cleanup
-    return () => {
-      if (timer) {
-        clearTimeout(timer);
-      }
-    };
-  }, [inputValue]);
 
   const onSend = () => {
     channel.publish("message", inputValue);
+    // When a message is sent, we want to turn off the typing indicator
+    // immediately.
+    onType("");
     setInputValue("");
-
-    if (startedTyping && timer) {
-      clearTimeout(timer);
-      setStartedTyping(false); // Reset the startedTyping state.
-      channel.publish("stoppedTyping", playerId);
-    }
   };
 
   const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const text = event.target.value;
     setInputValue(text);
+    onType(text);
   };
 
   const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -154,56 +51,40 @@ const Chat = () => {
     }
   };
 
-  const opponentIsTyping = whoIsCurrentlyTyping.filter((id) => id !== playerId);
-  const statusMessage =
-    opponentIsTyping.length > 0
-      ? `${playerName(opponentIsTyping[0], game.players)} is typing…`
-      : "";
-
   return (
     <div className="flex flex-col h-full">
       <ul className="p-2 grow bg-white min-h-[200px] sm:min-h-0">
         {messages.map((message) => {
           const name = playerName(message.clientId, game.players);
+          const isSystemMessage = !Boolean(name);
 
-          if (name) {
-            return (
-              <li key={message.id}>
-                <b>{name}:</b> {message.text}
-              </li>
-            );
-          } else {
+          if (isSystemMessage) {
             return (
               <li key={message.id} className="text-gray-500">
                 {message.text}
               </li>
             );
+          } else {
+            return (
+              <li key={message.id}>
+                <b
+                  className={`${
+                    name === playerNames[0] ? "text-orange-400" : ""
+                  } ${name === playerNames[1] ? "text-green-600" : ""}`}
+                >
+                  {name}:
+                </b>{" "}
+                {message.text}
+              </li>
+            );
           }
         })}
-        {shouldShowOpponentMessage && !opponentIsHere ? (
-          <>
-            <li className="text-gray-500">Your opponent has left the game.</li>
-          </>
-        ) : null}
-
-        {shouldShowOpponentMessage && !opponentIsHere && !gameResult ? (
-          <>
-            <li className="mt-2">
-              <a
-                onClick={() => {
-                  fetchGame(true);
-                }}
-                className="cursor-pointer underline underline-offset-2 text-blue-500"
-              >
-                Play again?
-              </a>
-            </li>
-          </>
-        ) : null}
+        <OpponentPresence />
       </ul>
-      <div className="p-2 text-xs text-gray-500">
-        {statusMessage ? statusMessage : "Chat"}
-      </div>
+      <Status
+        whoIsCurrentlyTyping={whoIsCurrentlyTyping}
+        className="p-2 text-xs text-gray-500"
+      />
       <div className="flex">
         <input
           className="grow p-2 focus:outline outline-4 outline-red-500"

--- a/src/app/components/chat/OpponentPresence.tsx
+++ b/src/app/components/chat/OpponentPresence.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useMemo, useState } from "react";
+import { usePresence } from "ably/react";
+import { useGameStateContext } from "../../app";
+
+// This component shows a message if the opponent has left the game.
+// It also provides an important link to restart the game if the opponent has
+// abandoned an in-progress game.
+const OpponentStatus = () => {
+  const { playerId, game, gameResult, fetchGame } = useGameStateContext();
+  if (!game) return;
+
+  // Use Ably's presence API to determine if the opponent is still connected
+  const { presenceData } = usePresence<string>(game.id, "present");
+
+  const [shouldShowOpponentMessage, setShouldShowOpponentMessage] =
+    useState(false);
+
+  const opponentId = useMemo(
+    () => game.players.filter((id) => id !== playerId)[0],
+    [game.players, playerId]
+  );
+
+  const opponentIsHere = useMemo(
+    () =>
+      Boolean(
+        presenceData.find((presence) => presence.clientId === opponentId)
+      ),
+    [presenceData, opponentId]
+  );
+
+  // Only show the opponent's status after a delay. This prevents an initial
+  // flicker in the chat window as the game gets underway.
+  useEffect(() => {
+    let timer: NodeJS.Timeout | null = null;
+
+    if (!opponentIsHere) {
+      timer = setTimeout(() => {
+        setShouldShowOpponentMessage(true);
+      }, 1000);
+    } else {
+      if (timer) {
+        clearTimeout(timer);
+      }
+      setShouldShowOpponentMessage(false);
+    }
+
+    return () => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    };
+  }, [opponentIsHere]);
+
+  return (
+    <>
+      {shouldShowOpponentMessage && !opponentIsHere ? (
+        <li className="text-gray-500">Your opponent has left the game.</li>
+      ) : null}
+      {shouldShowOpponentMessage && !opponentIsHere && !gameResult ? (
+        <li className="mt-2">
+          <a
+            onClick={() => {
+              fetchGame(true);
+            }}
+            className="cursor-pointer underline underline-offset-2 text-blue-500"
+          >
+            Play again?
+          </a>
+        </li>
+      ) : null}
+    </>
+  );
+};
+
+export default OpponentStatus;

--- a/src/app/components/chat/Status.tsx
+++ b/src/app/components/chat/Status.tsx
@@ -1,0 +1,35 @@
+import { useMemo } from "react";
+import { useGameStateContext } from "../../app";
+import { playerName } from "../../../gameUtils";
+
+type StatusProps = {
+  whoIsCurrentlyTyping: string[];
+  defaultText?: string;
+  className?: string;
+};
+
+const Status = ({
+  whoIsCurrentlyTyping,
+  defaultText = "Chat",
+  className = "",
+}: StatusProps) => {
+  const { game, playerId } = useGameStateContext();
+  if (!game) return;
+
+  // whoIsCurrentlyTyping tracks both players, but we only care about showing if
+  // the opponent is currently typing.
+  const opponentIsTyping = useMemo(
+    () => whoIsCurrentlyTyping.filter((id: string) => id !== playerId),
+    [whoIsCurrentlyTyping, playerId]
+  );
+
+  return (
+    <div className={`${className}`}>
+      {opponentIsTyping.length > 0
+        ? `${playerName(opponentIsTyping[0], game.players)} is typing…`
+        : defaultText}
+    </div>
+  );
+};
+
+export default Status;

--- a/src/app/components/chat/useTypingStatus.ts
+++ b/src/app/components/chat/useTypingStatus.ts
@@ -1,0 +1,79 @@
+import { useEffect, useState } from "react";
+import Ably from "ably/promises";
+
+// This hook is used to track which players are currently typing in a chat
+// Example Usage:
+//  const { onType, whoIsCurrentlyTyping } = useTypingStatus(channel, playerId);
+// <input onChange={(e) => onType(e.target.value)} />
+// {whoIsCurrentlyTyping.map((playerId) => (
+//   <p key={playerId}>{playerId} is typing...</p>
+// ))}
+const useTypingStatus = (
+  channel: Ably.Types.RealtimeChannelPromise,
+  playerId: string,
+  // How long to wait before considering a player to have stopped typing
+  timeoutDuration = 2000,
+) => {
+  const [startedTyping, setStartedTyping] = useState(false);
+  const [whoIsCurrentlyTyping, setWhoIsCurrentlyTyping] = useState<string[]>(
+    [],
+  );
+  const [timer, setTimer] = useState<NodeJS.Timeout | null>(null);
+
+  const stopTyping = () => {
+    setStartedTyping(false);
+    channel.publish("stoppedTyping", playerId);
+  };
+
+  const onType = (inputValue: string) => {
+    if (!startedTyping) {
+      setStartedTyping(true);
+      channel.publish("startedTyping", playerId);
+    }
+
+    if (timer) {
+      clearTimeout(timer);
+    }
+
+    if (inputValue === "") {
+      // Allow the typing indicator to be turned off immediately -- an empty
+      // string usually indicates either a sent message or a cleared input
+      stopTyping();
+    } else {
+      const newTimer = setTimeout(stopTyping, timeoutDuration);
+      setTimer(newTimer);
+    }
+  };
+
+  useEffect(() => {
+    const handleAblyMessage = (message: Ably.Types.Message) => {
+      const { name, clientId } = message;
+
+      if (name === "startedTyping") {
+        setWhoIsCurrentlyTyping((currentlyTyping) => [
+          ...currentlyTyping,
+          clientId,
+        ]);
+      }
+
+      if (name === "stoppedTyping") {
+        setWhoIsCurrentlyTyping((currentlyTyping) =>
+          currentlyTyping.filter((id) => id !== clientId)
+        );
+      }
+    };
+
+    channel.subscribe(handleAblyMessage);
+
+    return () => {
+      channel.unsubscribe(handleAblyMessage);
+      if (timer) {
+        clearTimeout(timer);
+      }
+    };
+  }, [channel]);
+
+  return { onType, whoIsCurrentlyTyping };
+};
+
+export default useTypingStatus;

--- a/src/gameUtils.ts
+++ b/src/gameUtils.ts
@@ -3,6 +3,19 @@ import { GameTypes } from "./types";
 // Use times / circle unicode symbols for player names instead of x and o
 export const playerNames = ["×", "○"];
 
+// Convert a player ID to a player name based on its position in the players
+// array, where, in our context, the first player is always X and the second
+// player is always O
+export const playerName = (playerId: string, players: string[]) => {
+  if (playerId === players[0]) {
+    return playerNames[0];
+  } else if (playerId === players[1]) {
+    return playerNames[1];
+  } else {
+    return;
+  }
+};
+
 export const translatePlayerName = (name: string) => {
   if (name === "x") {
     return playerNames[0];


### PR DESCRIPTION
* Pull out typing status logic into its own reusable custom hook
* Pull out opponent presence indicator into its own component
* Pull out status into its own component

Chat.tsx began at 228 lines; this commit reduces it to 109 lines.